### PR TITLE
bugfix(javadoc): fix </li> related javadoc issues

### DIFF
--- a/src/main/java/de/uniwuerzburg/zpd/ocr4all/application/ocrd/spi/ocr/provider/json/JsonTesserocrFontshape.java
+++ b/src/main/java/de/uniwuerzburg/zpd/ocr4all/application/ocrd/spi/ocr/provider/json/JsonTesserocrFontshape.java
@@ -29,7 +29,7 @@ import de.uniwuerzburg.zpd.ocr4all.application.spi.env.Framework;
  * <li>tesserocr-fontshape-json-id: ocrd-tesserocr-fontshape</li>
  * <li>tesserocr-fontshape-json-description: ocr-d tesserocr font shape
  * processor</li>
- * <li>tesserocr-fontshape-json-default-model: null</li></li>
+ * <li>tesserocr-fontshape-json-default-model: null</li>
  * <li>tesserocr-docker-resources: /usr/local/share/tessdata</li>
  * <li>tesserocr-recognize-json-id: ocrd-tesserocr-recognize</li>
  * </ul>

--- a/src/main/java/de/uniwuerzburg/zpd/ocr4all/application/ocrd/spi/ocr/provider/json/JsonTesserocrRecognize.java
+++ b/src/main/java/de/uniwuerzburg/zpd/ocr4all/application/ocrd/spi/ocr/provider/json/JsonTesserocrRecognize.java
@@ -44,7 +44,7 @@ import de.uniwuerzburg.zpd.ocr4all.application.spi.model.argument.StringArgument
  * <li>docker-stop-wait-kill-seconds: 2</li>
  * <li>tesserocr-recognize-json-id: ocrd-tesserocr-recognize</li>
  * <li>tesserocr-recognize-json-description: ocr-d tesserocr recognize processor
- * <li>tesserocr-recognize-json-default-model: null</li></li>
+ * <li>tesserocr-recognize-json-default-model: null</li>
  * <li>tesserocr-docker-resources: /usr/local/share/tessdata</li>
  * </ul>
  *

--- a/src/main/java/de/uniwuerzburg/zpd/ocr4all/application/ocrd/spi/ocr/provider/json/JsonTesserocrRecognize.java
+++ b/src/main/java/de/uniwuerzburg/zpd/ocr4all/application/ocrd/spi/ocr/provider/json/JsonTesserocrRecognize.java
@@ -43,7 +43,7 @@ import de.uniwuerzburg.zpd.ocr4all.application.spi.model.argument.StringArgument
  * <li>docker-image: ocrd/all:maximum</li>
  * <li>docker-stop-wait-kill-seconds: 2</li>
  * <li>tesserocr-recognize-json-id: ocrd-tesserocr-recognize</li>
- * <li>tesserocr-recognize-json-description: ocr-d tesserocr recognize processor
+ * <li>tesserocr-recognize-json-description: ocr-d tesserocr recognize processor</li>
  * <li>tesserocr-recognize-json-default-model: null</li>
  * <li>tesserocr-docker-resources: /usr/local/share/tessdata</li>
  * </ul>


### PR DESCRIPTION
Removes dangling `</li>` tags which lead to javadoc generation error (+ add missing </li> tag)